### PR TITLE
fix(ui): ensure TEMPORAL_UI_PORT is always set to prevent conflicts with k8s discovery environment variables

### DIFF
--- a/api/v1beta1/temporalcluster_defaults.go
+++ b/api/v1beta1/temporalcluster_defaults.go
@@ -29,7 +29,7 @@ const (
 	defaultTemporalVersion = "1.17.4"
 	defaultTemporalImage   = "temporalio/server"
 
-	defaultTemporalUIVersion = "2.5.0"
+	defaultTemporalUIVersion = "2.9.0"
 	defaultTemporalUIImage   = "temporalio/ui"
 
 	defaultTemporalAdmintoolsImage = "temporalio/admin-tools"

--- a/pkg/resource/ui_deployment_builder.go
+++ b/pkg/resource/ui_deployment_builder.go
@@ -79,8 +79,8 @@ func (b *UIDeploymentBuilder) Update(object client.Object) error {
 			Value: fmt.Sprintf("%s:%d", b.instance.ChildResourceName(FrontendService), *b.instance.Spec.Services.Frontend.Port),
 		},
 		{
-			Name:  "TEMPORAL_CORS_ORIGINS",
-			Value: "",
+			Name:  "TEMPORAL_UI_PORT",
+			Value: "8080",
 		},
 	}
 


### PR DESCRIPTION
This PR fixes #234 