### PR TITLE
Set resources for jobs and s3ForcePathStyle for archiver

### DIFF
--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -842,6 +842,9 @@ type S3Archiver struct {
 	// Use credentials if you want to use aws credentials from secret.
 	// +optional
 	Credentials *S3Credentials `json:"credentials,omitempty"`
+	// Use s3ForcePathStyle if you want to use s3 path style.
+	// +optional
+	S3ForcePathStyle bool `json:"s3ForcePathStyle"`
 }
 
 type S3Credentials struct {
@@ -879,6 +882,9 @@ type TemporalClusterSpec struct {
 	//+kubebuilder:default:=300
 	//+kubebuilder:validation:Minimum=1
 	JobTTLSecondsAfterFinished *int32 `json:"jobTtlSecondsAfterFinished"`
+	// JobResources allows set resources for setup/update jobs.
+	// +optional
+	JobResources corev1.ResourceRequirements `json:"jobResources,omitempty"`
 	// NumHistoryShards is the desired number of history shards.
 	// This field is immutable.
 	//+kubebuilder:validation:Minimum=1

--- a/config/crd/bases/temporal.io_temporalclusters.yaml
+++ b/config/crd/bases/temporal.io_temporalclusters.yaml
@@ -257,6 +257,10 @@ spec:
                             roleName:
                               description: Use RoleName if you want the temporal service account to assume an AWS Identity and Access Management (IAM) role.
                               type: string
+                            s3ForcePathStyle:
+                              default: false
+                              description: s3ForcePathStyle defines if the archival should use s3 path style.
+                              type: boolean
                           required:
                             - region
                           type: object
@@ -345,6 +349,43 @@ spec:
                   format: int32
                   minimum: 1
                   type: integer
+                jobResources:
+                  description: 'Compute Resources required by jobs. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    claims:
+                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
                 mTLS:
                   description: MTLS allows configuration of the network traffic encryption for the cluster.
                   properties:

--- a/internal/resource/persistence/schema_setup_job_builder.go
+++ b/internal/resource/persistence/schema_setup_job_builder.go
@@ -120,6 +120,7 @@ func (b *SchemaJobBuilder) Build() client.Object {
 							Name:                     "schema-script-runner",
 							Image:                    fmt.Sprintf("%s:%s", b.instance.Spec.AdminTools.Image, b.instance.Spec.Version),
 							ImagePullPolicy:          corev1.PullAlways,
+							Resources:                b.instance.Spec.JobResources,
 							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							Command:                  append([]string{"/bin/sh", "-c"}, b.command...),

--- a/pkg/temporal/archival/archival.go
+++ b/pkg/temporal/archival/archival.go
@@ -67,7 +67,7 @@ func S3ArchiverToTemporalS3Archiver(a *v1beta1.S3Archiver) *config.S3Archiver {
 	return &config.S3Archiver{
 		Region:           a.Region,
 		Endpoint:         a.Endpoint,
-		S3ForcePathStyle: false, // TODO(alexandrevilain): See implications
+		S3ForcePathStyle: a.S3ForcePathStyle,
 	}
 }
 


### PR DESCRIPTION
Hello!
We encountered 2 main problems when tried deploy temporal-operator in our k8s clusters.
1. In our clusters we have adminission controler that checks resource limits on every pod in the cluster. If you don't pass resource limits for pod you will not able to deploy it.
2. We work with s3 compatible storage provider that supports only path styled url's.

To resolve it I did:
1. Added ability to pass resources for init jobs from CRD.
2. Added ability to pass s3PathStyle from CRD.