### PR TITLE
Fix persistence scripts that are missing shutdown

### DIFF
--- a/internal/resource/persistence/template.go
+++ b/internal/resource/persistence/template.go
@@ -333,8 +333,6 @@ var proxyShutdownScriptsContent = dedent.Dedent(`
 
 func init() {
 	for name, content := range templatesContent {
-		//combinedContent := proxyShutdownScriptsContent + content
-		//templates[name] = template.Must(template.New(name).Parse(combinedContent))
 		templates[name] = template.Must(template.New(name).Parse(proxyShutdownScriptsContent))
 		template.Must(templates[name].Parse(content))
 	}

--- a/internal/resource/persistence/template.go
+++ b/internal/resource/persistence/template.go
@@ -50,14 +50,17 @@ var (
 		noOpTemplate: dedent.Dedent(`
 			#!/bin/bash
 			echo "No-op"
+			{{ template "scripts" . }}
 		`),
 		createCassandraTemplate: dedent.Dedent(`
 			#!/bin/bash
 			{{ .Tool }} {{ .ConnectionArgs }} create-Keyspace -k {{ .KeyspaceName }}
+			{{ template "scripts" . }}
 		`),
 		createDatabaseTemplate: dedent.Dedent(`
 			#!/bin/bash
 			{{ .Tool }} {{ .ConnectionArgs }} create-database -database {{ .DatabaseName }}
+			{{ template "scripts" . }}
 		`),
 		createDatabaseTemplateV1_18: dedent.Dedent(`
 			#!/bin/bash
@@ -330,6 +333,8 @@ var proxyShutdownScriptsContent = dedent.Dedent(`
 
 func init() {
 	for name, content := range templatesContent {
+		//combinedContent := proxyShutdownScriptsContent + content
+		//templates[name] = template.Must(template.New(name).Parse(combinedContent))
 		templates[name] = template.Must(template.New(name).Parse(proxyShutdownScriptsContent))
 		template.Must(templates[name].Parse(content))
 	}

--- a/internal/resource/persistence/template_test.go
+++ b/internal/resource/persistence/template_test.go
@@ -1,0 +1,38 @@
+// Licensed to Alexandre VILAIN under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Alexandre VILAIN licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package persistence
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplates(t *testing.T) {
+	var s strings.Builder
+	assert.NoError(t, templates[createDatabaseTemplate].Execute(&s, struct {
+		MTLSProvider   string
+		Tool           string
+		ConnectionArgs string
+		DatabaseName   string
+	}{
+		MTLSProvider: "linkerd",
+	}))
+	assert.Contains(t, s.String(), "curl -X POST http://localhost:4191/shutdown")
+}


### PR DESCRIPTION
Persistence scripts such as create database did not include the command to shut down the underlying proxies. This MR should fix that.