### PR TITLE
Fix Prometheus scraping port

### DIFF
--- a/internal/resource/prometheus/scrape_annotations.go
+++ b/internal/resource/prometheus/scrape_annotations.go
@@ -34,7 +34,7 @@ func GetAnnotations(instance *v1beta1.TemporalCluster) map[string]string {
 			"prometheus.io/scrape": "true",
 			"prometheus.io/scheme": "http",
 			"prometheus.io/path":   "/metrics",
-			"prometheus.io/port":   fmt.Sprintf("%d", instance.Spec.Metrics.Prometheus.ListenPort),
+			"prometheus.io/port":   fmt.Sprintf("%d", *instance.Spec.Metrics.Prometheus.ListenPort),
 		}
 	}
 	return map[string]string{}


### PR DESCRIPTION
This MR is to fix the Prometheus scraping port. The pointer address of `instance.Spec.Metrics.Prometheus.ListenPort` was used instead of the pointed value, which in turn caused pod crashing loop