### PR TITLE
fix(admintools): add mtls environment variables for temporal cli >= 0.9.0

### DIFF
--- a/examples/cluster-mtls/02-temporal-cluster.yaml
+++ b/examples/cluster-mtls/02-temporal-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prod
   namespace: demo
 spec:
-  version: 1.20.0
+  version: 1.21.2
   numHistoryShards: 1
   jobTtlSecondsAfterFinished: 300
   persistence:

--- a/internal/resource/admintools/deployment_builder.go
+++ b/internal/resource/admintools/deployment_builder.go
@@ -115,7 +115,10 @@ func (b *DeploymentBuilder) Update(object client.Object) error {
 			},
 		)
 
+		// Add tctl environment variables
 		env = append(env, certmanager.GetTLSEnvironmentVariables(b.instance, "TEMPORAL_CLI", admintoolsCertsMountPath)...)
+		// Add temporal cli environment variables (>= 0.9.0)
+		env = append(env, certmanager.GetTLSEnvironmentVariables(b.instance, "TEMPORAL", admintoolsCertsMountPath)...)
 	}
 
 	deployment.Spec.Replicas = pointer.Int32(1)

--- a/internal/resource/mtls/certmanager/env.go
+++ b/internal/resource/mtls/certmanager/env.go
@@ -50,6 +50,10 @@ func GetTLSEnvironmentVariables(instance *v1beta1.TemporalCluster, envPrefix, ce
 			Value: "true",
 		},
 		{
+			Name:  addPrefix(envPrefix, "TLS_DISABLE_HOST_VERIFICATION"),
+			Value: "false",
+		},
+		{
 			Name:  addPrefix(envPrefix, "TLS_SERVER_NAME"),
 			Value: instance.Spec.MTLS.Frontend.ServerName(instance.ServerName()),
 		},


### PR DESCRIPTION
This PR fixes #546 