### PR TITLE
Fix istio mTLS

### DIFF
--- a/api/v1beta1/temporalcluster_defaults.go
+++ b/api/v1beta1/temporalcluster_defaults.go
@@ -213,10 +213,13 @@ func (c *TemporalCluster) Default() {
 		c.Spec.AdminTools.Image = defaultTemporalAdmintoolsImage
 	}
 
-	if c.MTLSWithCertManagerEnabled() {
+	if c.Spec.MTLS != nil {
 		if c.Spec.MTLS.RefreshInterval == nil {
 			c.Spec.MTLS.RefreshInterval = &metav1.Duration{Duration: time.Hour}
 		}
+	}
+
+	if c.MTLSWithCertManagerEnabled() {
 		if c.Spec.MTLS.CertificatesDuration == nil {
 			c.Spec.MTLS.CertificatesDuration = &CertificatesDurationSpec{}
 		}


### PR DESCRIPTION
- fix `refreshInterval` default when using istio mTLS (not cert-manager)
- fix istio mTLS for Uber Ringpop: those two ports need to be explicitly listed in headless services otherwise Ringpop p2p cannot communicate with each other and result in bootstrap failure and container restarts