### PR TITLE
feat(config): add support for Metrics PerUnitHistogramBoundaries config

### DIFF
--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -743,6 +743,15 @@ type PrometheusSpec struct {
 type MetricsSpec struct {
 	// Enabled defines if the operator should enable metrics exposition on temporal components.
 	Enabled bool `json:"enabled"`
+	// PerUnitHistogramBoundaries defines the default histogram bucket boundaries.
+	// Configuration of histogram boundaries for given metric unit.
+	//
+	// Supported values:
+	// - "dimensionless"
+	// - "milliseconds"
+	// - "bytes"
+	// +optional
+	PerUnitHistogramBoundaries map[string][]string `json:"perUnitHistogramBoundaries,omitempty"`
 	// Prometheus reporter configuration.
 	// +optional
 	Prometheus *PrometheusSpec `json:"prometheus,omitempty"`

--- a/config/crd/bases/temporal.io_temporalclusters.yaml
+++ b/config/crd/bases/temporal.io_temporalclusters.yaml
@@ -501,6 +501,13 @@ spec:
                     enabled:
                       description: Enabled defines if the operator should enable metrics exposition on temporal components.
                       type: boolean
+                    perUnitHistogramBoundaries:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: "PerUnitHistogramBoundaries defines the default histogram bucket boundaries. Configuration of histogram boundaries for given metric unit. \n Supported values: - \"dimensionless\" - \"milliseconds\" - \"bytes\""
+                      type: object
                     prometheus:
                       description: Prometheus reporter configuration.
                       properties:

--- a/webhooks/temporalcluster_webhook.go
+++ b/webhooks/temporalcluster_webhook.go
@@ -273,6 +273,24 @@ func (w *TemporalClusterWebhook) validateCluster(cluster *v1beta1.TemporalCluste
 		}
 	}
 
+	// Check for per unit histogram boundaries if metrics is enabled
+	if cluster.Spec.Metrics.IsEnabled() && cluster.Spec.Metrics.PerUnitHistogramBoundaries != nil {
+		p := cluster.Spec.Metrics.PerUnitHistogramBoundaries
+		for _, value := range p {
+			for _, str := range value {
+				_, err := strconv.ParseFloat(str, 64)
+				if err != nil {
+					errs = append(errs,
+						field.Forbidden(
+							field.NewPath("spec", "metrics", "perUnitHistogramBoundaries"),
+							fmt.Sprintf("can't parse this strings value to float64: %s ", str),
+						),
+					)
+				}
+			}
+		}
+	}
+
 	return warns, errs
 }
 


### PR DESCRIPTION
Close: #565 
Add support for Metrics PerUnitHistogramBoundaries config. Locally tested successful with the config below.
```
  metrics:
    enabled: true
    perUnitHistogramBoundaries:
      dimensionless:
        - "51200"  
        - "100000"
      milliseconds:
        - "500000"
        - "1000000"
      bytes:
        - "2097152"
        - "4194304"