### PR TITLE
feat(webhook): Only allow Elasticsearch datastore type for advancedVisibility on clusters => 1.21

### DIFF
--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -369,7 +369,7 @@ const (
 // DatastoreSpec contains temporal datastore specifications.
 type DatastoreSpec struct {
 	// Name is the name of the datastore.
-	// It should be unique and will be referenced within the persitence spec.
+	// It should be unique and will be referenced within the persistence spec.
 	// Defaults to "default" for default sore, "visibility" for visibility store,
 	// "secondaryVisibility" for secondary visibility store and
 	// "advancedVisibility" for advanced visibility store.
@@ -476,7 +476,7 @@ type TemporalPersistenceSpec struct {
 	// Feature only available for clusters >= 1.21.0.
 	// +optional
 	SecondaryVisibilityStore *DatastoreSpec `json:"secondaryVisibilityStore,omitempty"`
-	// AdvancedVisibilityStore holds the avanced visibility datastore specs.
+	// AdvancedVisibilityStore holds the advanced visibility datastore specs.
 	// +optional
 	AdvancedVisibilityStore *DatastoreSpec `json:"advancedVisibilityStore,omitempty"`
 }
@@ -517,7 +517,7 @@ func (p *TemporalPersistenceSpec) GetDatastoresMap() map[string]*DatastoreSpec {
 
 // TemporalUIIngressSpec contains all configurations options for the UI ingress.
 type TemporalUIIngressSpec struct {
-	// Annotations allows custom annotations on the ingress ressource.
+	// Annotations allows custom annotations on the ingress resource.
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// IngressClassName is the name of the IngressClass the deployed ingress resource should use.
 	IngressClassName *string `json:"ingressClassName,omitempty"`
@@ -708,7 +708,7 @@ type PrometheusScrapeConfigServiceMonitor struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 	// Override allows customization of the created ServiceMonitor.
-	// All fields can be overritten except "endpoints", "selector" and "namespaceSelector".
+	// All fields can be overwritten except "endpoints", "selector" and "namespaceSelector".
 	// +optional
 	Override *monitoringv1.ServiceMonitorSpec `json:"override,omitempty"`
 	// MetricRelabelConfigs to apply to samples before ingestion.
@@ -796,7 +796,7 @@ type DynamicConfigSpec struct {
 	// Defaults to 10s.
 	// +optional
 	PollInterval *metav1.Duration `json:"pollInterval"`
-	// Values contains all dynamic config keys and their constained values.
+	// Values contains all dynamic config keys and their constrained values.
 	Values map[string][]ConstrainedValue `json:"values"`
 }
 
@@ -858,7 +858,7 @@ func (p *ArchivalProvider) Kind() ArchivalProviderKind {
 	return UnknownArchivalProviderKind
 }
 
-// ArchivalSpec is the archival configuration for a particular persistence type (history or visibilitty).
+// ArchivalSpec is the archival configuration for a particular persistence type (history or visibility).
 type ArchivalSpec struct {
 	// Enabled defines if the archival is enabled by default for all namespaces
 	// or for a particular namespace (depends if it's for a TemporalCluster or a TemporalNamespace).
@@ -1039,7 +1039,7 @@ type DatastoreStatus struct {
 	Created bool `json:"created"`
 	// Setup indicates if tables have been set up.
 	Setup bool `json:"setup"`
-	// Type indicates the datastore stype.
+	// Type indicates the datastore type.
 	// +optional
 	Type DatastoreType `json:"type"`
 	// SchemaVersion report the current schema version.
@@ -1056,7 +1056,7 @@ type TemporalPersistenceStatus struct {
 	// SecondaryVisibilityStore holds the secondary visibility datastore status.
 	// +optional
 	SecondaryVisibilityStore *DatastoreStatus `json:"secondaryVisibilityStore"`
-	// AdvancedVisibilityStore holds the avanced visibility datastore status.
+	// AdvancedVisibilityStore holds the advanced visibility datastore status.
 	// +optional
 	AdvancedVisibilityStore *DatastoreStatus `json:"advancedVisibilityStore,omitempty"`
 }

--- a/config/crd/bases/temporal.io_temporalclusters.yaml
+++ b/config/crd/bases/temporal.io_temporalclusters.yaml
@@ -348,7 +348,7 @@ spec:
                             - value
                           type: object
                         type: array
-                      description: Values contains all dynamic config keys and their constained values.
+                      description: Values contains all dynamic config keys and their constrained values.
                       type: object
                   required:
                     - values
@@ -593,22 +593,22 @@ spec:
                                     type: object
                                   type: array
                                 override:
-                                  description: Override allows customization of the created ServiceMonitor. All fields can be overritten except "endpoints", "selector" and "namespaceSelector".
+                                  description: Override allows customization of the created ServiceMonitor. All fields can be overwritten except "endpoints", "selector" and "namespaceSelector".
                                   properties:
                                     attachMetadata:
-                                      description: Attaches node metadata to discovered targets. Requires Prometheus v2.37.0 and above.
+                                      description: "`attachMetadata` defines additional metadata which is added to the discovered targets. \n It requires Prometheus >= v2.37.0."
                                       properties:
                                         node:
-                                          description: When set to true, Prometheus must have permissions to get Nodes.
+                                          description: When set to true, Prometheus must have the `get` permission on the `Nodes` objects.
                                           type: boolean
                                       type: object
                                     endpoints:
-                                      description: A list of endpoints allowed as part of this ServiceMonitor.
+                                      description: List of endpoints part of this ServiceMonitor.
                                       items:
-                                        description: Endpoint defines a scrapeable endpoint serving Prometheus metrics.
+                                        description: Endpoint defines an endpoint serving Prometheus metrics to be scraped by Prometheus.
                                         properties:
                                           authorization:
-                                            description: Authorization section for this endpoint
+                                            description: "`authorization` configures the Authorization header credentials to use when scraping the target. \n Cannot be set at the same time as `basicAuth`, or `oauth2`."
                                             properties:
                                               credentials:
                                                 description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
@@ -631,10 +631,10 @@ spec:
                                                 type: string
                                             type: object
                                           basicAuth:
-                                            description: 'BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                            description: "`basicAuth` configures the Basic Authentication credentials to use when scraping the target. \n Cannot be set at the same time as `authorization`, or `oauth2`."
                                             properties:
                                               password:
-                                                description: The secret in the service monitor namespace that contains the password for authentication.
+                                                description: '`password` specifies a key of a Secret containing the password for authentication.'
                                                 properties:
                                                   key:
                                                     description: The key of the secret to select from.  Must be a valid secret key.
@@ -650,7 +650,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               username:
-                                                description: The secret in the service monitor namespace that contains the username for authentication.
+                                                description: '`username` specifies a key of a Secret containing the username for authentication.'
                                                 properties:
                                                   key:
                                                     description: The key of the secret to select from.  Must be a valid secret key.
@@ -667,10 +667,10 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                           bearerTokenFile:
-                                            description: File to read bearer token for scraping targets.
+                                            description: "File to read bearer token for scraping the target. \n Deprecated: use `authorization` instead."
                                             type: string
                                           bearerTokenSecret:
-                                            description: Secret to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator.
+                                            description: "`bearerTokenSecret` specifies a key of a Secret containing the bearer token for scraping targets. The secret needs to be in the same namespace as the ServiceMonitor object and readable by the Prometheus Operator. \n Deprecated: use `authorization` instead."
                                             properties:
                                               key:
                                                 description: The key of the secret to select from.  Must be a valid secret key.
@@ -686,26 +686,26 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           enableHttp2:
-                                            description: Whether to enable HTTP2.
+                                            description: '`enableHttp2` can be used to disable HTTP2 when scraping the target.'
                                             type: boolean
                                           filterRunning:
-                                            description: 'Drop pods that are not running. (Failed, Succeeded). Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                                            description: "When true, the pods which are not running (e.g. either in Failed or Succeeded state) are dropped during the target discovery. \n If unset, the filtering is enabled. \n More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase"
                                             type: boolean
                                           followRedirects:
-                                            description: FollowRedirects configures whether scrape requests follow HTTP 3xx redirects.
+                                            description: '`followRedirects` defines whether the scrape requests should follow HTTP 3xx redirects.'
                                             type: boolean
                                           honorLabels:
-                                            description: HonorLabels chooses the metric's labels on collisions with target labels.
+                                            description: When true, `honorLabels` preserves the metric's labels when they collide with the target's labels.
                                             type: boolean
                                           honorTimestamps:
-                                            description: HonorTimestamps controls whether Prometheus respects the timestamps present in scraped data.
+                                            description: '`honorTimestamps` controls whether Prometheus preserves the timestamps when exposed by the target.'
                                             type: boolean
                                           interval:
-                                            description: Interval at which metrics should be scraped If not specified Prometheus' global scrape interval is used.
+                                            description: "Interval at which Prometheus scrapes the metrics from the target. \n If empty, Prometheus uses the global scrape interval."
                                             pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                                             type: string
                                           metricRelabelings:
-                                            description: MetricRelabelConfigs to apply to samples before ingestion.
+                                            description: '`metricRelabelings` configures the relabeling rules to apply to the samples before ingestion.'
                                             items:
                                               description: "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                                               properties:
@@ -762,10 +762,10 @@ spec:
                                               type: object
                                             type: array
                                           oauth2:
-                                            description: OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
+                                            description: "`oauth2` configures the OAuth2 settings to use when scraping the target. \n It requires Prometheus >= 2.27.0. \n Cannot be set at the same time as `authorization`, or `basicAuth`."
                                             properties:
                                               clientId:
-                                                description: The secret or configmap containing the OAuth2 client id
+                                                description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                                 properties:
                                                   configMap:
                                                     description: ConfigMap containing data to use for the targets.
@@ -801,7 +801,7 @@ spec:
                                                     x-kubernetes-map-type: atomic
                                                 type: object
                                               clientSecret:
-                                                description: The secret containing the OAuth2 client secret
+                                                description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                                 properties:
                                                   key:
                                                     description: The key of the secret to select from.  Must be a valid secret key.
@@ -819,15 +819,15 @@ spec:
                                               endpointParams:
                                                 additionalProperties:
                                                   type: string
-                                                description: Parameters to append to the token URL
+                                                description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                                 type: object
                                               scopes:
-                                                description: OAuth2 scopes used for the token request
+                                                description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                                 items:
                                                   type: string
                                                 type: array
                                               tokenUrl:
-                                                description: The URL to fetch the token from
+                                                description: '`tokenURL` configures the URL to fetch the token from.'
                                                 minLength: 1
                                                 type: string
                                             required:
@@ -840,19 +840,19 @@ spec:
                                               items:
                                                 type: string
                                               type: array
-                                            description: Optional HTTP URL parameters
+                                            description: params define optional HTTP URL parameters.
                                             type: object
                                           path:
-                                            description: HTTP path to scrape for metrics. If empty, Prometheus uses the default value (e.g. `/metrics`).
+                                            description: "HTTP path from which to scrape for metrics. \n If empty, Prometheus uses the default value (e.g. `/metrics`)."
                                             type: string
                                           port:
-                                            description: Name of the service port this endpoint refers to. Mutually exclusive with targetPort.
+                                            description: "Name of the Service port which this endpoint refers to. \n It takes precedence over `targetPort`."
                                             type: string
                                           proxyUrl:
-                                            description: ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.
+                                            description: '`proxyURL` configures the HTTP Proxy URL (e.g. "http://proxyserver:2195") to go through when scraping the target.'
                                             type: string
                                           relabelings:
-                                            description: 'RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job''s name is available via the `__tmp_prometheus_job_name` label. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                                            description: "`relabelings` configures the relabeling rules to apply the target's metadata labels. \n The Operator automatically adds relabelings for a few standard Kubernetes fields. \n The original scrape job's name is available via the `__tmp_prometheus_job_name` label. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                                             items:
                                               description: "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                                               properties:
@@ -909,23 +909,23 @@ spec:
                                               type: object
                                             type: array
                                           scheme:
-                                            description: HTTP scheme to use for scraping. `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. If empty, Prometheus uses the default value `http`.
+                                            description: "HTTP scheme to use for scraping. \n `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. \n If empty, Prometheus uses the default value `http`."
                                             enum:
                                               - http
                                               - https
                                             type: string
                                           scrapeTimeout:
-                                            description: Timeout after which the scrape is ended If not specified, the Prometheus global scrape timeout is used unless it is less than `Interval` in which the latter is used.
+                                            description: "Timeout after which Prometheus considers the scrape to be failed. \n If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used."
                                             pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                                             type: string
                                           targetPort:
                                             anyOf:
                                               - type: integer
                                               - type: string
-                                            description: Name or number of the target port of the Pod behind the Service, the port must be specified with container port property. Mutually exclusive with port.
+                                            description: "Name or number of the target port of the `Pod` object behind the Service, the port must be specified with container port property. \n Deprecated: use `port` instead."
                                             x-kubernetes-int-or-string: true
                                           tlsConfig:
-                                            description: TLS configuration to use when scraping the endpoint
+                                            description: TLS configuration to use when scraping the target.
                                             properties:
                                               ca:
                                                 description: Certificate authority used when verifying server certificates.
@@ -1031,25 +1031,32 @@ spec:
                                                 description: Used to verify the hostname for the targets.
                                                 type: string
                                             type: object
+                                          trackTimestampsStaleness:
+                                            description: "`trackTimestampsStaleness` defines whether Prometheus tracks staleness of the metrics that have an explicit timestamp present in scraped data. Has no effect if `honorTimestamps` is false. \n It requires Prometheus >= v2.48.0."
+                                            type: boolean
                                         type: object
                                       type: array
                                     jobLabel:
-                                      description: "JobLabel selects the label from the associated Kubernetes service which will be used as the `job` label for all metrics. \n For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo: bar`, then the `job=\"bar\"` label is added to all metrics. \n If the value of this field is empty or if the label doesn't exist for the given Service, the `job` label of the metrics defaults to the name of the Kubernetes Service."
+                                      description: "`jobLabel` selects the label from the associated Kubernetes `Service` object which will be used as the `job` label for all metrics. \n For example if `jobLabel` is set to `foo` and the Kubernetes `Service` object is labeled with `foo: bar`, then Prometheus adds the `job=\"bar\"` label to all ingested metrics. \n If the value of this field is empty or if the label doesn't exist for the given Service, the `job` label of the metrics defaults to the name of the associated Kubernetes `Service`."
                                       type: string
+                                    keepDroppedTargets:
+                                      description: "Per-scrape limit on the number of targets dropped by relabeling that will be kept in memory. 0 means no limit. \n It requires Prometheus >= v2.47.0."
+                                      format: int64
+                                      type: integer
                                     labelLimit:
-                                      description: Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                                      description: "Per-scrape limit on number of labels that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                                       format: int64
                                       type: integer
                                     labelNameLengthLimit:
-                                      description: Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                                      description: "Per-scrape limit on length of labels name that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                                       format: int64
                                       type: integer
                                     labelValueLengthLimit:
-                                      description: Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                                      description: "Per-scrape limit on length of labels value that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                                       format: int64
                                       type: integer
                                     namespaceSelector:
-                                      description: Selector to select which namespaces the Kubernetes Endpoints objects are discovered from.
+                                      description: Selector to select which namespaces the Kubernetes `Endpoints` objects are discovered from.
                                       properties:
                                         any:
                                           description: Boolean describing whether all namespaces are selected in contrast to a list restricting them.
@@ -1061,16 +1068,16 @@ spec:
                                           type: array
                                       type: object
                                     podTargetLabels:
-                                      description: PodTargetLabels transfers labels on the Kubernetes `Pod` onto the created metrics.
+                                      description: '`podTargetLabels` defines the labels which are transferred from the associated Kubernetes `Pod` object onto the ingested metrics.'
                                       items:
                                         type: string
                                       type: array
                                     sampleLimit:
-                                      description: SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+                                      description: '`sampleLimit` defines a per-scrape limit on the number of scraped samples that will be accepted.'
                                       format: int64
                                       type: integer
                                     selector:
-                                      description: Selector to select Endpoints objects.
+                                      description: Label selector to select the Kubernetes `Endpoints` objects.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -1101,16 +1108,15 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetLabels:
-                                      description: TargetLabels transfers labels from the Kubernetes `Service` onto the created metrics.
+                                      description: '`targetLabels` defines the labels which are transferred from the associated Kubernetes `Service` object onto the ingested metrics.'
                                       items:
                                         type: string
                                       type: array
                                     targetLimit:
-                                      description: TargetLimit defines a limit on the number of scraped targets that will be accepted.
+                                      description: '`targetLimit` defines a limit on the number of scraped targets that will be accepted.'
                                       format: int64
                                       type: integer
                                   required:
-                                    - endpoints
                                     - selector
                                   type: object
                               type: object
@@ -1128,7 +1134,7 @@ spec:
                   description: Persistence defines temporal persistence configuration.
                   properties:
                     advancedVisibilityStore:
-                      description: AdvancedVisibilityStore holds the avanced visibility datastore specs.
+                      description: AdvancedVisibilityStore holds the advanced visibility datastore specs.
                       properties:
                         cassandra:
                           description: Cassandra holds all connection parameters for Cassandra datastore. Note that cassandra is now deprecated for visibility store.
@@ -1235,7 +1241,7 @@ spec:
                             - version
                           type: object
                         name:
-                          description: Name is the name of the datastore. It should be unique and will be referenced within the persitence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
+                          description: Name is the name of the datastore. It should be unique and will be referenced within the persistence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
                           type: string
                         passwordSecretRef:
                           description: PasswordSecret is the reference to the secret holding the password.
@@ -1461,7 +1467,7 @@ spec:
                             - version
                           type: object
                         name:
-                          description: Name is the name of the datastore. It should be unique and will be referenced within the persitence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
+                          description: Name is the name of the datastore. It should be unique and will be referenced within the persistence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
                           type: string
                         passwordSecretRef:
                           description: PasswordSecret is the reference to the secret holding the password.
@@ -1687,7 +1693,7 @@ spec:
                             - version
                           type: object
                         name:
-                          description: Name is the name of the datastore. It should be unique and will be referenced within the persitence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
+                          description: Name is the name of the datastore. It should be unique and will be referenced within the persistence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
                           type: string
                         passwordSecretRef:
                           description: PasswordSecret is the reference to the secret holding the password.
@@ -1913,7 +1919,7 @@ spec:
                             - version
                           type: object
                         name:
-                          description: Name is the name of the datastore. It should be unique and will be referenced within the persitence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
+                          description: Name is the name of the datastore. It should be unique and will be referenced within the persistence spec. Defaults to "default" for default sore, "visibility" for visibility store, "secondaryVisibility" for secondary visibility store and "advancedVisibility" for advanced visibility store.
                           type: string
                         passwordSecretRef:
                           description: PasswordSecret is the reference to the secret holding the password.
@@ -2621,7 +2627,7 @@ spec:
                         annotations:
                           additionalProperties:
                             type: string
-                          description: Annotations allows custom annotations on the ingress ressource.
+                          description: Annotations allows custom annotations on the ingress resource.
                           type: object
                         hosts:
                           description: Host is the list of host the ingress should use.
@@ -2816,7 +2822,7 @@ spec:
                   description: Persistence holds all datastores statuses.
                   properties:
                     advancedVisibilityStore:
-                      description: AdvancedVisibilityStore holds the avanced visibility datastore status.
+                      description: AdvancedVisibilityStore holds the advanced visibility datastore status.
                       properties:
                         created:
                           description: Created indicates if the database or keyspace has been created.
@@ -2828,7 +2834,7 @@ spec:
                           description: Setup indicates if tables have been set up.
                           type: boolean
                         type:
-                          description: Type indicates the datastore stype.
+                          description: Type indicates the datastore type.
                           type: string
                       required:
                         - created
@@ -2847,7 +2853,7 @@ spec:
                           description: Setup indicates if tables have been set up.
                           type: boolean
                         type:
-                          description: Type indicates the datastore stype.
+                          description: Type indicates the datastore type.
                           type: string
                       required:
                         - created
@@ -2866,7 +2872,7 @@ spec:
                           description: Setup indicates if tables have been set up.
                           type: boolean
                         type:
-                          description: Type indicates the datastore stype.
+                          description: Type indicates the datastore type.
                           type: string
                       required:
                         - created
@@ -2885,7 +2891,7 @@ spec:
                           description: Setup indicates if tables have been set up.
                           type: boolean
                         type:
-                          description: Type indicates the datastore stype.
+                          description: Type indicates the datastore type.
                           type: string
                       required:
                         - created

--- a/docs/api/v1beta1.md
+++ b/docs/api/v1beta1.md
@@ -561,7 +561,7 @@ GCSArchiver
 <a href="#temporal.io/v1beta1.ClusterArchivalSpec">ClusterArchivalSpec</a>, 
 <a href="#temporal.io/v1beta1.TemporalNamespaceArchivalSpec">TemporalNamespaceArchivalSpec</a>)
 </p>
-<p>ArchivalSpec is the archival configuration for a particular persistence type (history or visibilitty).</p>
+<p>ArchivalSpec is the archival configuration for a particular persistence type (history or visibility).</p>
 <div class="md-typeset__scrollwrap">
 <div class="md-typeset__table">
 <table>
@@ -1322,7 +1322,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Name is the name of the datastore.
-It should be unique and will be referenced within the persitence spec.
+It should be unique and will be referenced within the persistence spec.
 Defaults to &ldquo;default&rdquo; for default sore, &ldquo;visibility&rdquo; for visibility store,
 &ldquo;secondaryVisibility&rdquo; for secondary visibility store and
 &ldquo;advancedVisibility&rdquo; for advanced visibility store.</p>
@@ -1464,7 +1464,7 @@ DatastoreType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Type indicates the datastore stype.</p>
+<p>Type indicates the datastore type.</p>
 </td>
 </tr>
 <tr>
@@ -1715,7 +1715,7 @@ map[string][]./api/v1beta1.ConstrainedValue
 </em>
 </td>
 <td>
-<p>Values contains all dynamic config keys and their constained values.</p>
+<p>Values contains all dynamic config keys and their constrained values.</p>
 </td>
 </tr>
 </tbody>
@@ -2625,7 +2625,7 @@ github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.Servic
 <td>
 <em>(Optional)</em>
 <p>Override allows customization of the created ServiceMonitor.
-All fields can be overritten except &ldquo;endpoints&rdquo;, &ldquo;selector&rdquo; and &ldquo;namespaceSelector&rdquo;.</p>
+All fields can be overwritten except &ldquo;endpoints&rdquo;, &ldquo;selector&rdquo; and &ldquo;namespaceSelector&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -4422,7 +4422,7 @@ DatastoreSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>AdvancedVisibilityStore holds the avanced visibility datastore specs.</p>
+<p>AdvancedVisibilityStore holds the advanced visibility datastore specs.</p>
 </td>
 </tr>
 </tbody>
@@ -4497,7 +4497,7 @@ DatastoreStatus
 </td>
 <td>
 <em>(Optional)</em>
-<p>AdvancedVisibilityStore holds the avanced visibility datastore status.</p>
+<p>AdvancedVisibilityStore holds the advanced visibility datastore status.</p>
 </td>
 </tr>
 </tbody>
@@ -4529,7 +4529,7 @@ map[string]string
 </em>
 </td>
 <td>
-<p>Annotations allows custom annotations on the ingress ressource.</p>
+<p>Annotations allows custom annotations on the ingress resource.</p>
 </td>
 </tr>
 <tr>

--- a/webhooks/temporalcluster_webhook.go
+++ b/webhooks/temporalcluster_webhook.go
@@ -262,8 +262,17 @@ func (w *TemporalClusterWebhook) validateCluster(cluster *v1beta1.TemporalCluste
 	if cluster.Spec.Version.GreaterOrEqual(version.V1_21_0) {
 		if cluster.Spec.Persistence.AdvancedVisibilityStore != nil {
 			warns = append(warns,
-				"Starting from temporal >= 1.21 standard visibility becomes advanced visibility. Advanced visibility configuration is now moved to standard visibility. Please only use visibility datastore configuration. Avanced visibility store usage will be forbidden by the operator for clusters >= 1.23.",
+				"Starting from temporal >= 1.21 standard visibility becomes advanced visibility. Advanced visibility configuration is now moved to standard visibility. Please only use visibility datastore configuration. Advanced visibility store usage will be forbidden by the operator for clusters >= 1.23.",
 			)
+
+			if cluster.Spec.Persistence.AdvancedVisibilityStore.GetType() != v1beta1.ElasticsearchDatastore {
+				errs = append(errs,
+					field.Forbidden(
+						field.NewPath("spec", "persistence", "advancedVisibilityStore"),
+						"Temporal cluster version >= 1.21.0 only supports Elasticsearch as an advanced visibility store, use standard visibility store instead.",
+					),
+				)
+			}
 		}
 
 		if cluster.Spec.Persistence.VisibilityStore != nil && cluster.Spec.Persistence.VisibilityStore.Cassandra != nil {


### PR DESCRIPTION
Fixes #515