### PR TITLE
fix(persistence): ensure unique mount paths for datastore tls ca, cert, and key

### DIFF
--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -433,9 +433,15 @@ func (s *DatastoreSpec) IsSQL() bool {
 
 const (
 	dataStoreTLSCertificateBasePath = "/etc/tls/datastores"
-	DataStoreClientTLSCertFileName  = "client.pem"
-	DataStoreClientTLSKeyFileName   = "client.key"
-	DataStoreClientTLSCaFileName    = "ca.pem"
+	dataStoreTLSCAPrefix            = "ca"
+	dataStoreTLSCertPrefix          = "cert"
+	dataStoreTLSKeyPrefix           = "key"
+	// DataStoreClientTLSCertFileName is the default client TLS cert file name.
+	DataStoreClientTLSCertFileName = "client.pem"
+	// DataStoreClientTLSKeyFileName is the default client TLS key file name.
+	DataStoreClientTLSKeyFileName = "client.key"
+	// DataStoreClientTLSCaFileName is the default client TLS ca file name.
+	DataStoreClientTLSCaFileName = "ca.pem"
 )
 
 // GetTLSKeyFileMountPath returns the client TLS cert mount path.
@@ -445,7 +451,7 @@ func (s *DatastoreSpec) GetTLSCertFileMountPath() string {
 		return ""
 	}
 
-	return path.Join(dataStoreTLSCertificateBasePath, s.Name, DataStoreClientTLSCertFileName)
+	return path.Join(dataStoreTLSCertificateBasePath, dataStoreTLSCertPrefix, s.Name, DataStoreClientTLSCertFileName)
 }
 
 // GetTLSKeyFileMountPath returns the client TLS key mount path.
@@ -454,7 +460,7 @@ func (s *DatastoreSpec) GetTLSKeyFileMountPath() string {
 	if s.TLS == nil || s.TLS.KeyFileRef == nil {
 		return ""
 	}
-	return path.Join(dataStoreTLSCertificateBasePath, s.Name, DataStoreClientTLSKeyFileName)
+	return path.Join(dataStoreTLSCertificateBasePath, dataStoreTLSKeyPrefix, s.Name, DataStoreClientTLSKeyFileName)
 }
 
 // GetTLSCaFileMountPath  returns the CA key mount path.
@@ -463,7 +469,7 @@ func (s *DatastoreSpec) GetTLSCaFileMountPath() string {
 	if s.TLS == nil || s.TLS.CaFileRef == nil {
 		return ""
 	}
-	return path.Join(dataStoreTLSCertificateBasePath, s.Name, DataStoreClientTLSCaFileName)
+	return path.Join(dataStoreTLSCertificateBasePath, dataStoreTLSCAPrefix, s.Name, DataStoreClientTLSCaFileName)
 }
 
 // GetPasswordEnvVarName crafts the environment variable name for the datastore.

--- a/internal/resource/persistence/utils_test.go
+++ b/internal/resource/persistence/utils_test.go
@@ -358,7 +358,7 @@ func TestGetDatastoresVolumeMounts(t *testing.T) {
 			expectedEnvVars: []corev1.VolumeMount{
 				{
 					Name:      "test-tls-ca-file",
-					MountPath: "/etc/tls/datastores/test",
+					MountPath: "/etc/tls/datastores/ca/test",
 				},
 			},
 		},
@@ -377,7 +377,7 @@ func TestGetDatastoresVolumeMounts(t *testing.T) {
 			expectedEnvVars: []corev1.VolumeMount{
 				{
 					Name:      "test-tls-cert-file",
-					MountPath: "/etc/tls/datastores/test",
+					MountPath: "/etc/tls/datastores/cert/test",
 				},
 			},
 		},
@@ -396,7 +396,7 @@ func TestGetDatastoresVolumeMounts(t *testing.T) {
 			expectedEnvVars: []corev1.VolumeMount{
 				{
 					Name:      "test-tls-key-file",
-					MountPath: "/etc/tls/datastores/test",
+					MountPath: "/etc/tls/datastores/key/test",
 				},
 			},
 		},


### PR DESCRIPTION
This PR fixes #626 