### PR TITLE
fix(rbac): add missing permissions to helm clusterrole

### DIFF
--- a/charts/temporal-operator/templates/manager-rbac.yaml
+++ b/charts/temporal-operator/templates/manager-rbac.yaml
@@ -11,6 +11,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - get
   - list
   - update
@@ -207,6 +208,32 @@ rules:
   - temporal.io
   resources:
   - temporalnamespaces/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - temporal.io
+  resources:
+  - temporalschedules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - temporal.io
+  resources:
+  - temporalschedules/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - temporal.io
+  resources:
+  - temporalschedules/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
This PR fixes missing permissions for the helm chart (recent addition of [schedules support](https://github.com/alexandrevilain/temporal-operator/pull/736) and [configmap deletion](https://github.com/alexandrevilain/temporal-operator/pull/739)).