### PR TITLE
Updating links to Prometheus Operator docs in PrometheusScrapeConfigServiceMonitor

### DIFF
--- a/docs/api/v1beta1.md
+++ b/docs/api/v1beta1.md
@@ -2388,7 +2388,7 @@ map[string]string
 <td>
 <code>override</code><br>
 <em>
-<a href="https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitorSpec">
+<a href="https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitorSpec">
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.ServiceMonitorSpec
 </a>
 </em>
@@ -2403,7 +2403,7 @@ All fields can be overwritten except &ldquo;endpoints&rdquo;, &ldquo;selector&rd
 <td>
 <code>metricRelabelings</code><br>
 <em>
-<a href="https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.RelabelConfig">
+<a href="https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.RelabelConfig">
 []github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.RelabelConfig
 </a>
 </em>


### PR DESCRIPTION
Not sure if this is a recent change, but current links (using `/operator/` path segment) result in 404; just subbing it for `/api-reference/` does the trick.