### PR TITLE
Helm chart: bump app version to v0.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,6 @@ prepare-release: kustomize
 	$(eval OLD_VERSION := $(shell curl -s https://api.github.com/repos/alexandrevilain/temporal-operator/releases | jq -r '.[0].tag_name'))
 	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/alexandrevilain/temporal-operator:v$(VERSION)
 	sed -i'' -e 's/replaces: temporal-operator.v.*/replaces: temporal-operator.$(OLD_VERSION)/' config/manifests/bases/temporal-operator.clusterserviceversion.yaml
-	sed -i '' 's/^appVersion: ".*"/appVersion: "$(VERSION)"/' charts/temporal-operator/Chart.yaml
 	$(MAKE) bundle
 
 OPERATOR_HUB_FORK_REPOSITORY ?= git@github.com:alexandrevilain/community-operators.git

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ artifacts: kustomize
 
 .PHONY: helm
 helm: helm-docs manifests artifacts
+	sed -i '' 's/^appVersion: ".*"/appVersion: "v$(shell cat VERSION)"/' charts/temporal-operator/Chart.yaml
 	cp ${RELEASE_PATH}/temporal-operator.crds.yaml charts/temporal-operator/crds
 	$(HELM_DOCS) --chart-search-root=charts/temporal-operator --template-files=hack/helm/template/README.md.gotmpl
 

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ prepare-release: kustomize
 	$(eval OLD_VERSION := $(shell curl -s https://api.github.com/repos/alexandrevilain/temporal-operator/releases | jq -r '.[0].tag_name'))
 	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/alexandrevilain/temporal-operator:v$(VERSION)
 	sed -i'' -e 's/replaces: temporal-operator.v.*/replaces: temporal-operator.$(OLD_VERSION)/' config/manifests/bases/temporal-operator.clusterserviceversion.yaml
+	sed -i '' 's/^appVersion: ".*"/appVersion: "$(VERSION)"/' charts/temporal-operator/Chart.yaml
 	$(MAKE) bundle
 
 OPERATOR_HUB_FORK_REPOSITORY ?= git@github.com:alexandrevilain/community-operators.git

--- a/charts/temporal-operator/Chart.yaml
+++ b/charts/temporal-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.19.0"
+appVersion: "v0.20.0"

--- a/charts/temporal-operator/Chart.yaml
+++ b/charts/temporal-operator/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.6.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.20.0"
+appVersion: "v0.19.0"

--- a/charts/temporal-operator/Chart.yaml
+++ b/charts/temporal-operator/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.6.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.19.0"
+appVersion: "v0.20.0"

--- a/charts/temporal-operator/README.md
+++ b/charts/temporal-operator/README.md
@@ -1,6 +1,6 @@
 # Temporal Operator Helm Chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.16.1](https://img.shields.io/badge/AppVersion-v0.16.1-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
 
 This Helm chart deploys the Temporal Operator to manage a Temporal Cluster in a Kubernetes cluster.
 
@@ -36,10 +36,12 @@ helm install [RELEASE_NAME] temporal-operator/temporal-operator
 | manager.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Security context for the controller manager container. |
 | manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Disallow privilege escalation for the container. |
 | manager.image.repository | string | `"ghcr.io/alexandrevilain/temporal-operator"` | Docker image repository for the controller manager container. |
+| manager.nodeSelector | object | `{}` |  |
 | manager.replicas | int | `1` | Number of controller manager replicas to deploy. |
 | manager.resources.limits | object | `{"cpu":"500m","memory":"128Mi"}` | Resources limits for the controller manager container. |
 | manager.resources.requests | object | `{"cpu":"10m","memory":"64Mi"}` | Resources requests for the controller manager container. |
 | manager.serviceAccount | object | `{"annotations":{}}` | Service account settings for the controller manager container. |
+| manager.tolerations | list | `[]` |  |
 | webhook.certManager | object | `{"certificate":{"enabled":true,"issuerRef":{},"useCustomIssuer":false}}` | Certificate manager settings for the webhook server. |
 | webhook.certManager.certificate | object | `{"enabled":true,"issuerRef":{},"useCustomIssuer":false}` | Webhook certificate configuration using cert-manager.  |
 | webhook.certManager.certificate.enabled | bool | `true` | Enabled defines if cert-manager should be used to manage the webhook certificate. |

--- a/charts/temporal-operator/README.md
+++ b/charts/temporal-operator/README.md
@@ -1,6 +1,6 @@
 # Temporal Operator Helm Chart
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.20.0](https://img.shields.io/badge/AppVersion-v0.20.0-informational?style=flat-square)
 
 This Helm chart deploys the Temporal Operator to manage a Temporal Cluster in a Kubernetes cluster.
 

--- a/charts/temporal-operator/crds/temporal-operator.crds.yaml
+++ b/charts/temporal-operator/crds/temporal-operator.crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: temporalclusterclients.temporal.io
 spec:
   group: temporal.io
@@ -70,9 +70,7 @@ spec:
                       This field is effectively required, but due to backwards compatibility is
                       allowed to be empty. Instances of this type with an empty value here are
                       almost certainly wrong.
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -92,7 +90,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: temporalclusters.temporal.io
 spec:
   group: temporal.io
@@ -224,10 +222,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -238,6 +234,12 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -271,6 +273,10 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  version:
+                    description: Version defines the temporal admin tools version
+                      the instance should run.
+                    type: string
                 type: object
               archival:
                 description: Archival allows Workflow Execution Event Histories and
@@ -351,9 +357,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key
@@ -388,9 +392,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the Secret or its
@@ -415,9 +417,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                   optional:
                                     description: Specify whether the Secret or its
@@ -584,9 +584,7 @@ spec:
                         This field is effectively required, but due to backwards compatibility is
                         allowed to be empty. Instances of this type with an empty value here are
                         almost certainly wrong.
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -608,10 +606,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -622,6 +618,12 @@ spec:
                             Name must match the name of one entry in pod.spec.resourceClaims of
                             the Pod where this field is used. It makes that resource available
                             inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
                           type: string
                       required:
                       - name
@@ -816,7 +818,6 @@ spec:
                       PerUnitHistogramBoundaries defines the default histogram bucket boundaries.
                       Configuration of histogram boundaries for given metric unit.
 
-
                       Supported values:
                       - "dimensionless"
                       - "milliseconds"
@@ -864,7 +865,6 @@ spec:
                                     RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                                     scraped samples and remote write samples.
 
-
                                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                                   properties:
                                     action:
@@ -872,10 +872,8 @@ spec:
                                       description: |-
                                         Action to perform based on the regex matching.
 
-
                                         `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
-
 
                                         Default: "Replace"
                                       enum:
@@ -906,7 +904,6 @@ spec:
                                       description: |-
                                         Modulus to take of the hash of the source label values.
 
-
                                         Only applicable when the action is `HashMod`.
                                       format: int64
                                       type: integer
@@ -918,7 +915,6 @@ spec:
                                       description: |-
                                         Replacement value against which a Replace action is performed if the
                                         regular expression matches.
-
 
                                         Regex capture groups are available.
                                       type: string
@@ -942,10 +938,8 @@ spec:
                                       description: |-
                                         Label to which the resulting string is written in a replacement.
 
-
                                         It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                                         `KeepEqual` and `DropEqual` actions.
-
 
                                         Regex capture groups are available.
                                       type: string
@@ -961,13 +955,15 @@ spec:
                                       `attachMetadata` defines additional metadata which is added to the
                                       discovered targets.
 
-
                                       It requires Prometheus >= v2.37.0.
                                     properties:
                                       node:
                                         description: |-
-                                          When set to true, Prometheus must have the `get` permission on the
-                                          `Nodes` objects.
+                                          When set to true, Prometheus attaches node metadata to the discovered
+                                          targets.
+
+                                          The Prometheus service account must have the `list` and `watch`
+                                          permissions on the `Nodes` objects.
                                         type: boolean
                                     type: object
                                   bodySizeLimit:
@@ -975,12 +971,14 @@ spec:
                                       When defined, bodySizeLimit specifies a job level limit on the size
                                       of uncompressed response body that will be accepted by Prometheus.
 
-
                                       It requires Prometheus >= v2.28.0.
                                     pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                                     type: string
                                   endpoints:
-                                    description: List of endpoints part of this ServiceMonitor.
+                                    description: |-
+                                      List of endpoints part of this ServiceMonitor.
+                                      Defines how to scrape metrics from Kubernetes [Endpoints](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) objects.
+                                      In most cases, an Endpoints object is backed by a Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object with the same name and labels.
                                     items:
                                       description: |-
                                         Endpoint defines an endpoint serving Prometheus metrics to be scraped by
@@ -990,7 +988,6 @@ spec:
                                           description: |-
                                             `authorization` configures the Authorization header credentials to use when
                                             scraping the target.
-
 
                                             Cannot be set at the same time as `basicAuth`, or `oauth2`.
                                           properties:
@@ -1011,9 +1008,7 @@ spec:
                                                     This field is effectively required, but due to backwards compatibility is
                                                     allowed to be empty. Instances of this type with an empty value here are
                                                     almost certainly wrong.
-                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1027,9 +1022,7 @@ spec:
                                               description: |-
                                                 Defines the authentication type. The value is case-insensitive.
 
-
                                                 "Basic" is not a supported value.
-
 
                                                 Default: "Bearer"
                                               type: string
@@ -1038,7 +1031,6 @@ spec:
                                           description: |-
                                             `basicAuth` configures the Basic Authentication credentials to use when
                                             scraping the target.
-
 
                                             Cannot be set at the same time as `authorization`, or `oauth2`.
                                           properties:
@@ -1059,9 +1051,7 @@ spec:
                                                     This field is effectively required, but due to backwards compatibility is
                                                     allowed to be empty. Instances of this type with an empty value here are
                                                     almost certainly wrong.
-                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1088,9 +1078,7 @@ spec:
                                                     This field is effectively required, but due to backwards compatibility is
                                                     allowed to be empty. Instances of this type with an empty value here are
                                                     almost certainly wrong.
-                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1105,7 +1093,6 @@ spec:
                                           description: |-
                                             File to read bearer token for scraping the target.
 
-
                                             Deprecated: use `authorization` instead.
                                           type: string
                                         bearerTokenSecret:
@@ -1113,7 +1100,6 @@ spec:
                                             `bearerTokenSecret` specifies a key of a Secret containing the bearer
                                             token for scraping targets. The secret needs to be in the same namespace
                                             as the ServiceMonitor object and readable by the Prometheus Operator.
-
 
                                             Deprecated: use `authorization` instead.
                                           properties:
@@ -1129,9 +1115,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -1150,9 +1134,7 @@ spec:
                                             When true, the pods which are not running (e.g. either in Failed or
                                             Succeeded state) are dropped during the target discovery.
 
-
                                             If unset, the filtering is enabled.
-
 
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
                                           type: boolean
@@ -1175,7 +1157,6 @@ spec:
                                           description: |-
                                             Interval at which Prometheus scrapes the metrics from the target.
 
-
                                             If empty, Prometheus uses the global scrape interval.
                                           pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                                           type: string
@@ -1188,7 +1169,6 @@ spec:
                                               RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                                               scraped samples and remote write samples.
 
-
                                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                                             properties:
                                               action:
@@ -1196,10 +1176,8 @@ spec:
                                                 description: |-
                                                   Action to perform based on the regex matching.
 
-
                                                   `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
-
 
                                                   Default: "Replace"
                                                 enum:
@@ -1230,7 +1208,6 @@ spec:
                                                 description: |-
                                                   Modulus to take of the hash of the source label values.
 
-
                                                   Only applicable when the action is `HashMod`.
                                                 format: int64
                                                 type: integer
@@ -1242,7 +1219,6 @@ spec:
                                                 description: |-
                                                   Replacement value against which a Replace action is performed if the
                                                   regular expression matches.
-
 
                                                   Regex capture groups are available.
                                                 type: string
@@ -1266,10 +1242,8 @@ spec:
                                                 description: |-
                                                   Label to which the resulting string is written in a replacement.
 
-
                                                   It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                                                   `KeepEqual` and `DropEqual` actions.
-
 
                                                   Regex capture groups are available.
                                                 type: string
@@ -1279,9 +1253,7 @@ spec:
                                           description: |-
                                             `oauth2` configures the OAuth2 settings to use when scraping the target.
 
-
                                             It requires Prometheus >= 2.27.0.
-
 
                                             Cannot be set at the same time as `authorization`, or `basicAuth`.
                                           properties:
@@ -1304,9 +1276,7 @@ spec:
                                                         This field is effectively required, but due to backwards compatibility is
                                                         allowed to be empty. Instances of this type with an empty value here are
                                                         almost certainly wrong.
-                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                       type: string
                                                     optional:
                                                       description: Specify whether
@@ -1333,9 +1303,7 @@ spec:
                                                         This field is effectively required, but due to backwards compatibility is
                                                         allowed to be empty. Instances of this type with an empty value here are
                                                         almost certainly wrong.
-                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                       type: string
                                                     optional:
                                                       description: Specify whether
@@ -1364,9 +1332,7 @@ spec:
                                                     This field is effectively required, but due to backwards compatibility is
                                                     allowed to be empty. Instances of this type with an empty value here are
                                                     almost certainly wrong.
-                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1383,12 +1349,247 @@ spec:
                                                 `endpointParams` configures the HTTP parameters to append to the token
                                                 URL.
                                               type: object
+                                            noProxy:
+                                              description: |-
+                                                `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                                                that should be excluded from proxying. IP and domain names can
+                                                contain port numbers.
+
+                                                It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                              type: string
+                                            proxyConnectHeader:
+                                              additionalProperties:
+                                                items:
+                                                  description: SecretKeySelector selects
+                                                    a key of a Secret.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                type: array
+                                              description: |-
+                                                ProxyConnectHeader optionally specifies headers to send to
+                                                proxies during CONNECT requests.
+
+                                                It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            proxyFromEnvironment:
+                                              description: |-
+                                                Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                                                It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                              type: boolean
+                                            proxyUrl:
+                                              description: '`proxyURL` defines the
+                                                HTTP proxy server to use.'
+                                              pattern: ^http(s)?://.+$
+                                              type: string
                                             scopes:
                                               description: '`scopes` defines the OAuth2
                                                 scopes used for the token request.'
                                               items:
                                                 type: string
                                               type: array
+                                            tlsConfig:
+                                              description: |-
+                                                TLS configuration to use when connecting to the OAuth2 server.
+                                                It requires Prometheus >= v2.43.0.
+                                              properties:
+                                                ca:
+                                                  description: Certificate authority
+                                                    used when verifying server certificates.
+                                                  properties:
+                                                    configMap:
+                                                      description: ConfigMap containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key to
+                                                            select.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the ConfigMap or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secret:
+                                                      description: Secret containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                cert:
+                                                  description: Client certificate
+                                                    to present when doing client-authentication.
+                                                  properties:
+                                                    configMap:
+                                                      description: ConfigMap containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key to
+                                                            select.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the ConfigMap or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secret:
+                                                      description: Secret containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                insecureSkipVerify:
+                                                  description: Disable target certificate
+                                                    validation.
+                                                  type: boolean
+                                                keySecret:
+                                                  description: Secret containing the
+                                                    client key file for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                maxVersion:
+                                                  description: |-
+                                                    Maximum acceptable TLS version.
+
+                                                    It requires Prometheus >= v2.41.0.
+                                                  enum:
+                                                  - TLS10
+                                                  - TLS11
+                                                  - TLS12
+                                                  - TLS13
+                                                  type: string
+                                                minVersion:
+                                                  description: |-
+                                                    Minimum acceptable TLS version.
+
+                                                    It requires Prometheus >= v2.35.0.
+                                                  enum:
+                                                  - TLS10
+                                                  - TLS11
+                                                  - TLS12
+                                                  - TLS13
+                                                  type: string
+                                                serverName:
+                                                  description: Used to verify the
+                                                    hostname for the targets.
+                                                  type: string
+                                              type: object
                                             tokenUrl:
                                               description: '`tokenURL` configures
                                                 the URL to fetch the token from.'
@@ -1411,13 +1612,11 @@ spec:
                                           description: |-
                                             HTTP path from which to scrape for metrics.
 
-
                                             If empty, Prometheus uses the default value (e.g. `/metrics`).
                                           type: string
                                         port:
                                           description: |-
                                             Name of the Service port which this endpoint refers to.
-
 
                                             It takes precedence over `targetPort`.
                                           type: string
@@ -1431,19 +1630,15 @@ spec:
                                             `relabelings` configures the relabeling rules to apply the target's
                                             metadata labels.
 
-
                                             The Operator automatically adds relabelings for a few standard Kubernetes fields.
 
-
                                             The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
-
 
                                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                                           items:
                                             description: |-
                                               RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                                               scraped samples and remote write samples.
-
 
                                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                                             properties:
@@ -1452,10 +1647,8 @@ spec:
                                                 description: |-
                                                   Action to perform based on the regex matching.
 
-
                                                   `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
-
 
                                                   Default: "Replace"
                                                 enum:
@@ -1486,7 +1679,6 @@ spec:
                                                 description: |-
                                                   Modulus to take of the hash of the source label values.
 
-
                                                   Only applicable when the action is `HashMod`.
                                                 format: int64
                                                 type: integer
@@ -1498,7 +1690,6 @@ spec:
                                                 description: |-
                                                   Replacement value against which a Replace action is performed if the
                                                   regular expression matches.
-
 
                                                   Regex capture groups are available.
                                                 type: string
@@ -1522,10 +1713,8 @@ spec:
                                                 description: |-
                                                   Label to which the resulting string is written in a replacement.
 
-
                                                   It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                                                   `KeepEqual` and `DropEqual` actions.
-
 
                                                   Regex capture groups are available.
                                                 type: string
@@ -1535,10 +1724,8 @@ spec:
                                           description: |-
                                             HTTP scheme to use for scraping.
 
-
                                             `http` and `https` are the expected values unless you rewrite the
                                             `__scheme__` label via relabeling.
-
 
                                             If empty, Prometheus uses the default value `http`.
                                           enum:
@@ -1548,7 +1735,6 @@ spec:
                                         scrapeTimeout:
                                           description: |-
                                             Timeout after which Prometheus considers the scrape to be failed.
-
 
                                             If empty, Prometheus uses the global scrape timeout unless it is less
                                             than the target's scrape interval value in which the latter is used.
@@ -1584,9 +1770,7 @@ spec:
                                                         This field is effectively required, but due to backwards compatibility is
                                                         allowed to be empty. Instances of this type with an empty value here are
                                                         almost certainly wrong.
-                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                       type: string
                                                     optional:
                                                       description: Specify whether
@@ -1613,9 +1797,7 @@ spec:
                                                         This field is effectively required, but due to backwards compatibility is
                                                         allowed to be empty. Instances of this type with an empty value here are
                                                         almost certainly wrong.
-                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                       type: string
                                                     optional:
                                                       description: Specify whether
@@ -1650,9 +1832,7 @@ spec:
                                                         This field is effectively required, but due to backwards compatibility is
                                                         allowed to be empty. Instances of this type with an empty value here are
                                                         almost certainly wrong.
-                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                       type: string
                                                     optional:
                                                       description: Specify whether
@@ -1679,9 +1859,7 @@ spec:
                                                         This field is effectively required, but due to backwards compatibility is
                                                         allowed to be empty. Instances of this type with an empty value here are
                                                         almost certainly wrong.
-                                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                       type: string
                                                     optional:
                                                       description: Specify whether
@@ -1723,9 +1901,7 @@ spec:
                                                     This field is effectively required, but due to backwards compatibility is
                                                     allowed to be empty. Instances of this type with an empty value here are
                                                     almost certainly wrong.
-                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1735,6 +1911,28 @@ spec:
                                               - key
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            maxVersion:
+                                              description: |-
+                                                Maximum acceptable TLS version.
+
+                                                It requires Prometheus >= v2.41.0.
+                                              enum:
+                                              - TLS10
+                                              - TLS11
+                                              - TLS12
+                                              - TLS13
+                                              type: string
+                                            minVersion:
+                                              description: |-
+                                                Minimum acceptable TLS version.
+
+                                                It requires Prometheus >= v2.35.0.
+                                              enum:
+                                              - TLS10
+                                              - TLS11
+                                              - TLS12
+                                              - TLS13
+                                              type: string
                                             serverName:
                                               description: Used to verify the hostname
                                                 for the targets.
@@ -1746,7 +1944,6 @@ spec:
                                             the metrics that have an explicit timestamp present in scraped data.
                                             Has no effect if `honorTimestamps` is false.
 
-
                                             It requires Prometheus >= v2.48.0.
                                           type: boolean
                                       type: object
@@ -1756,11 +1953,9 @@ spec:
                                       `jobLabel` selects the label from the associated Kubernetes `Service`
                                       object which will be used as the `job` label for all metrics.
 
-
                                       For example if `jobLabel` is set to `foo` and the Kubernetes `Service`
                                       object is labeled with `foo: bar`, then Prometheus adds the `job="bar"`
                                       label to all ingested metrics.
-
 
                                       If the value of this field is empty or if the label doesn't exist for
                                       the given Service, the `job` label of the metrics defaults to the name
@@ -1771,14 +1966,12 @@ spec:
                                       Per-scrape limit on the number of targets dropped by relabeling
                                       that will be kept in memory. 0 means no limit.
 
-
                                       It requires Prometheus >= v2.47.0.
                                     format: int64
                                     type: integer
                                   labelLimit:
                                     description: |-
                                       Per-scrape limit on number of labels that will be accepted for a sample.
-
 
                                       It requires Prometheus >= v2.27.0.
                                     format: int64
@@ -1787,7 +1980,6 @@ spec:
                                     description: |-
                                       Per-scrape limit on length of labels name that will be accepted for a sample.
 
-
                                       It requires Prometheus >= v2.27.0.
                                     format: int64
                                     type: integer
@@ -1795,14 +1987,13 @@ spec:
                                     description: |-
                                       Per-scrape limit on length of labels value that will be accepted for a sample.
 
-
                                       It requires Prometheus >= v2.27.0.
                                     format: int64
                                     type: integer
                                   namespaceSelector:
                                     description: |-
-                                      Selector to select which namespaces the Kubernetes `Endpoints` objects
-                                      are discovered from.
+                                      `namespaceSelector` defines in which namespace(s) Prometheus should discover the services.
+                                      By default, the services are discovered in the same namespace as the `ServiceMonitor` object but it is possible to select pods across different/all namespaces.
                                     properties:
                                       any:
                                         description: |-
@@ -1816,6 +2007,23 @@ spec:
                                           type: string
                                         type: array
                                     type: object
+                                  nativeHistogramBucketLimit:
+                                    description: |-
+                                      If there are more than this many buckets in a native histogram,
+                                      buckets will be merged to stay within the limit.
+                                      It requires Prometheus >= v2.45.0.
+                                    format: int64
+                                    type: integer
+                                  nativeHistogramMinBucketFactor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      If the growth factor of one bucket to the next is smaller than this,
+                                      buckets will be merged to increase the factor sufficiently.
+                                      It requires Prometheus >= v2.50.0.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   podTargetLabels:
                                     description: |-
                                       `podTargetLabels` defines the labels which are transferred from the
@@ -1833,14 +2041,17 @@ spec:
                                     description: The scrape class to apply.
                                     minLength: 1
                                     type: string
+                                  scrapeClassicHistograms:
+                                    description: |-
+                                      Whether to scrape a classic histogram that is also exposed as a native histogram.
+                                      It requires Prometheus >= v2.45.0.
+                                    type: boolean
                                   scrapeProtocols:
                                     description: |-
                                       `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
                                       protocols supported by Prometheus in order of preference (from most to least preferred).
 
-
                                       If unset, Prometheus uses its default value.
-
 
                                       It requires Prometheus >= v2.49.0.
                                     items:
@@ -1861,7 +2072,7 @@ spec:
                                     x-kubernetes-list-type: set
                                   selector:
                                     description: Label selector to select the Kubernetes
-                                      `Endpoints` objects.
+                                      `Endpoints` objects to scrape metrics from.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -1921,6 +2132,7 @@ spec:
                                     format: int64
                                     type: integer
                                 required:
+                                - endpoints
                                 - selector
                                 type: object
                             type: object
@@ -3042,6 +3254,7 @@ spec:
                           HTTPPort defines a custom http port for the service.
                           Default values are:
                           7243 for Frontend service
+                        format: int32
                         type: integer
                       initContainers:
                         description: InitContainers adds a list of init containers
@@ -3060,6 +3273,7 @@ spec:
                           6934 for History service
                           6935 for Matching service
                           6939 for Worker service
+                        format: int32
                         type: integer
                       overrides:
                         description: |-
@@ -3134,6 +3348,7 @@ spec:
                           7234 for History service
                           7235 for Matching service
                           7239 for Worker service
+                        format: int32
                         type: integer
                       replicas:
                         description: Number of desired replicas for the service. Default
@@ -3151,10 +3366,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -3165,6 +3378,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3207,6 +3426,7 @@ spec:
                           HTTPPort defines a custom http port for the service.
                           Default values are:
                           7243 for Frontend service
+                        format: int32
                         type: integer
                       initContainers:
                         description: InitContainers adds a list of init containers
@@ -3225,6 +3445,7 @@ spec:
                           6934 for History service
                           6935 for Matching service
                           6939 for Worker service
+                        format: int32
                         type: integer
                       overrides:
                         description: |-
@@ -3299,6 +3520,7 @@ spec:
                           7234 for History service
                           7235 for Matching service
                           7239 for Worker service
+                        format: int32
                         type: integer
                       replicas:
                         description: Number of desired replicas for the service. Default
@@ -3316,10 +3538,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -3330,6 +3550,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3379,6 +3605,7 @@ spec:
                           HTTPPort defines a custom http port for the service.
                           Default values are:
                           7243 for Frontend service
+                        format: int32
                         type: integer
                       initContainers:
                         description: InitContainers adds a list of init containers
@@ -3397,6 +3624,7 @@ spec:
                           6934 for History service
                           6935 for Matching service
                           6939 for Worker service
+                        format: int32
                         type: integer
                       overrides:
                         description: |-
@@ -3471,6 +3699,7 @@ spec:
                           7234 for History service
                           7235 for Matching service
                           7239 for Worker service
+                        format: int32
                         type: integer
                       replicas:
                         description: Number of desired replicas for the service. Default
@@ -3488,10 +3717,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -3502,6 +3729,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3544,6 +3777,7 @@ spec:
                           HTTPPort defines a custom http port for the service.
                           Default values are:
                           7243 for Frontend service
+                        format: int32
                         type: integer
                       initContainers:
                         description: InitContainers adds a list of init containers
@@ -3562,6 +3796,7 @@ spec:
                           6934 for History service
                           6935 for Matching service
                           6939 for Worker service
+                        format: int32
                         type: integer
                       overrides:
                         description: |-
@@ -3636,6 +3871,7 @@ spec:
                           7234 for History service
                           7235 for Matching service
                           7239 for Worker service
+                        format: int32
                         type: integer
                       replicas:
                         description: Number of desired replicas for the service. Default
@@ -3653,10 +3889,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -3667,6 +3901,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -3774,6 +4014,7 @@ spec:
                           HTTPPort defines a custom http port for the service.
                           Default values are:
                           7243 for Frontend service
+                        format: int32
                         type: integer
                       initContainers:
                         description: InitContainers adds a list of init containers
@@ -3792,6 +4033,7 @@ spec:
                           6934 for History service
                           6935 for Matching service
                           6939 for Worker service
+                        format: int32
                         type: integer
                       overrides:
                         description: |-
@@ -3866,6 +4108,7 @@ spec:
                           7234 for History service
                           7235 for Matching service
                           7239 for Worker service
+                        format: int32
                         type: integer
                       replicas:
                         description: Number of desired replicas for the service. Default
@@ -3883,10 +4126,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -3897,6 +4138,12 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used. It makes that resource available
                                     inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -4073,10 +4320,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -4087,6 +4332,12 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -4160,16 +4411,8 @@ spec:
                 description: Conditions represent the latest available observations
                   of the Cluster state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -4210,12 +4453,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -4352,7 +4590,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: temporalnamespaces.temporal.io
 spec:
   group: temporal.io
@@ -4510,16 +4748,8 @@ spec:
                 description: Conditions represent the latest available observations
                   of the Namespace state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -4560,12 +4790,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -4590,7 +4815,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: temporalschedules.temporal.io
 spec:
   group: temporal.io
@@ -4740,7 +4965,6 @@ spec:
                               and value type must be registered on Temporal server side. For supported operations on different server versions
                               see [Visibility].
 
-
                               [Visibility]: https://docs.temporal.io/visibility
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -4781,27 +5005,20 @@ spec:
                           Overlap controls what happens when an Action would be started by a
                           Schedule at the same time that an older Action is still running.
 
-
                           Supported values:
 
-
                           "skip" - Default. Nothing happens; the Workflow Execution is not started.
-
 
                           "bufferOne" - Starts the Workflow Execution as soon as the current one completes.
                           The buffer is limited to one. If another Workflow Execution is supposed to start,
                           but one is already in the buffer, only the one in the buffer eventually starts.
 
-
                           "bufferAll" - Allows an unlimited number of Workflows to buffer. They are started sequentially.
-
 
                           "cancelOther" - Cancels the running Workflow Execution, and then starts the new one
                           after the old one completes cancellation.
 
-
                           "terminateOther" - Terminates the running Workflow Execution and starts the new one immediately.
-
 
                           "allowAll" - Starts any number of concurrent Workflow Executions.
                           With this policy (and only this policy), more than one Workflow Execution,
@@ -5114,14 +5331,14 @@ spec:
                           For new\nuse cases, we recommend using ScheduleSpec.Calendars
                           or ScheduleSpec.\nIntervals for readability and maintainability.
                           Once a schedule is created all\nexpressions in Crons will
-                          be translated to ScheduleSpec.Calendars on the server.\n\n\nFor
-                          example, `0 12 * * MON-WED,FRI` is every M/Tu/W/F at noon\n\n\nThe
+                          be translated to ScheduleSpec.Calendars on the server.\n\nFor
+                          example, `0 12 * * MON-WED,FRI` is every M/Tu/W/F at noon\n\nThe
                           string can have 5, 6, or 7 fields, separated by spaces,
-                          and they are interpreted in the\nsame way as a ScheduleCalendarSpec:\n\n\n\t-
-                          5 fields:         Minute, Hour, DayOfMonth, Month, DayOfWeek\n\n\n\t-
+                          and they are interpreted in the\nsame way as a ScheduleCalendarSpec:\n\n\t-
+                          5 fields:         Minute, Hour, DayOfMonth, Month, DayOfWeek\n\n\t-
                           6 fields:         Minute, Hour, DayOfMonth, Month, DayOfWeek,
-                          Year\n\n\n\t- 7 fields: Second, Minute, Hour, DayOfMonth,
-                          Month, DayOfWeek, Year\n\n\nNotes:\n\t- If Year is not given,
+                          Year\n\n\t- 7 fields: Second, Minute, Hour, DayOfMonth,
+                          Month, DayOfWeek, Year\n\nNotes:\n\t- If Year is not given,
                           it defaults to *.\n\t- If Second is not given, it defaults
                           to 0.\n\t- Shorthands @yearly, @monthly, @weekly, @daily,
                           and @hourly are also\n\t\taccepted instead of the 5-7 time
@@ -5150,7 +5367,6 @@ spec:
                       excludeCalendars:
                         description: |-
                           ExcludeCalendars defines any matching times that will be skipped.
-
 
                           All fields of the ScheduleCalendarSpec including seconds must match a time for the time to be skipped.
                         items:
@@ -5439,9 +5655,9 @@ spec:
                           of times.
                         items:
                           description: "ScheduleIntervalSpec matches times that can
-                            be expressed as:\n\n\n\tEpoch + (n * every) + offset\n\n\n\twhere
-                            n is all integers ≥ 0.\n\n\nFor example, an `every` of
-                            1 hour with `offset` of zero would match every hour, on
+                            be expressed as:\n\n\tEpoch + (n * every) + offset\n\n\twhere
+                            n is all integers ≥ 0.\n\nFor example, an `every` of 1
+                            hour with `offset` of zero would match every hour, on
                             the hour. The same `every` but an `offset`\nof 19 minutes
                             would match every `xx:19:00`. An `every` of 28 days with
                             `offset` zero would match `2022-02-17T00:00:00Z`\n(among
@@ -5480,16 +5696,13 @@ spec:
                         description: |-
                           TimeZoneName represents the IANA time zone name, for example `US/Pacific`.
 
-
                           The definition will be loaded by Temporal Server from the environment it runs in.
-
 
                           Calendar spec matching is based on literal matching of the clock time
                           with no special handling of DST: if you write a calendar spec that fires
                           at 2:30am and specify a time zone that follows DST, that action will not
                           be triggered on the day that has no 2:30am. Similarly, an action that
                           fires at 1:30am will be triggered twice on the day that has two 1:30s.
-
 
                           Note: No actions are taken on leap-seconds (e.g. 23:59:60 UTC).
                           Defaults to UTC.
@@ -5527,7 +5740,6 @@ spec:
                   and value type must be registered on Temporal server side. For supported operations on different server versions
                   see [Visibility].
 
-
                   [Visibility]: https://docs.temporal.io/visibility
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -5542,16 +5754,8 @@ spec:
                 description: Conditions represent the latest available observations
                   of the Schedule state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -5592,12 +5796,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/temporal.io_temporalclusters.yaml
+++ b/config/crd/bases/temporal.io_temporalclusters.yaml
@@ -1774,6 +1774,23 @@ spec:
                                             type: string
                                           type: array
                                       type: object
+                                    nativeHistogramBucketLimit:
+                                      description: |-
+                                        If there are more than this many buckets in a native histogram,
+                                        buckets will be merged to stay within the limit.
+                                        It requires Prometheus >= v2.45.0.
+                                      format: int64
+                                      type: integer
+                                    nativeHistogramMinBucketFactor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: |-
+                                        If the growth factor of one bucket to the next is smaller than this,
+                                        buckets will be merged to increase the factor sufficiently.
+                                        It requires Prometheus >= v2.50.0.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
                                     podTargetLabels:
                                       description: |-
                                         `podTargetLabels` defines the labels which are transferred from the
@@ -1791,6 +1808,11 @@ spec:
                                       description: The scrape class to apply.
                                       minLength: 1
                                       type: string
+                                    scrapeClassicHistograms:
+                                      description: |-
+                                        Whether to scrape a classic histogram that is also exposed as a native histogram.
+                                        It requires Prometheus >= v2.45.0.
+                                      type: boolean
                                     scrapeProtocols:
                                       description: |-
                                         `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the


### PR DESCRIPTION
This bumps the app version to v0.20.0 and updates the `prepare-release` task in the `Makefile` to update the `appVersion` in the Helm chart.