### PR TITLE
fix: Add manual workflow trigger

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,6 +1,7 @@
 name: Release Charts
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main


### PR DESCRIPTION
To force manual chart release after fix in 6eef5d06823ed7a6f69685ed2cd02c7c6aea2183:

This should make it possible to manually trigger the chart release workflow.