### PR TITLE
fix(admintools): add defaults for v1.23.x

### DIFF
--- a/docs/features/admin-tools.md
+++ b/docs/features/admin-tools.md
@@ -21,3 +21,4 @@ spec:
     # https://hub.docker.com/r/temporalio/admin-tools/tags
     version: 1.24.2-tctl-1.18.1-cli-1.0.0
 ```
+Note: You need helm chart version 0.6.0 or above to specify admintools version.

--- a/pkg/version/admintools.go
+++ b/pkg/version/admintools.go
@@ -5,6 +5,12 @@ import "fmt"
 // DefaultAdminToolTag returns the tag of the admin tools image for the given version.
 // It's required as 1.24.x had really bad image tagging.
 func DefaultAdminToolTag(version *Version) string {
+	// Particular case for >= 1.23.0 but < 1.24.0
+	// Need this because 1.23.1 tag does not exist
+	if version.GreaterOrEqual(V1_23_0) && version.LessThan(V1_24_0) {
+		return "1.23.1.1-tctl-1.18.1-cli-0.12.0"
+	}
+
 	// Particular case for >= 1.24.0 but < 1.25.0
 	if version.GreaterOrEqual(V1_24_0) && version.LessThan(V1_25_0) {
 		return "1.24.2-tctl-1.18.1-cli-1.0.0"

--- a/pkg/version/admintools_test.go
+++ b/pkg/version/admintools_test.go
@@ -14,6 +14,16 @@ func TestDefaultAdminToolTag(t *testing.T) {
 		expected string
 	}{
 		{
+			name:     "Version 1.23.0",
+			version:  version.MustNewVersionFromString("1.23.0"),
+			expected: "1.23.1.1-tctl-1.18.1-cli-0.12.0",
+		},
+		{
+			name:     "Version 1.23.9",
+			version:  version.MustNewVersionFromString("1.23.9"),
+			expected: "1.23.1.1-tctl-1.18.1-cli-0.12.0",
+		},
+		{
 			name:     "Version 1.24.1",
 			version:  version.MustNewVersionFromString("1.24.1"),
 			expected: "1.24.2-tctl-1.18.1-cli-1.0.0",


### PR DESCRIPTION
1.23.1 tag does not exist for admintools so the pod gets stuck in ImagePullBackOff error state: https://hub.docker.com/r/temporalio/admin-tools/tags?name=1.23