### PR TITLE
fix: use internal frontend in GetPublicClientAddress when enabled

### DIFF
--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -1182,6 +1182,10 @@ func (c *TemporalCluster) ChildResourceName(resource string) string {
 }
 
 func (c *TemporalCluster) GetPublicClientAddress() string {
+	// If mTLS frontend is enabled, always use the public frontend address
+	if c.Spec.MTLS != nil && c.Spec.MTLS.Frontend != nil && c.Spec.MTLS.Frontend.Enabled {
+		return fmt.Sprintf("%s.%s:%d", c.ChildResourceName("frontend"), c.GetNamespace(), *c.Spec.Services.Frontend.Port)
+	}
 	// Use internal frontend if it's enabled, otherwise use regular frontend
 	if c.Spec.Services != nil && c.Spec.Services.InternalFrontend.IsEnabled() {
 		return fmt.Sprintf("%s.%s:%d", c.ChildResourceName("internal-frontend-headless"), c.GetNamespace(), *c.Spec.Services.InternalFrontend.Port)

--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -1182,6 +1182,10 @@ func (c *TemporalCluster) ChildResourceName(resource string) string {
 }
 
 func (c *TemporalCluster) GetPublicClientAddress() string {
+	// Use internal frontend if it's enabled, otherwise use regular frontend
+	if c.Spec.Services != nil && c.Spec.Services.InternalFrontend.IsEnabled() {
+		return fmt.Sprintf("%s.%s:%d", c.ChildResourceName("internalFrontend"), c.GetNamespace(), *c.Spec.Services.InternalFrontend.Port)
+	}
 	return fmt.Sprintf("%s.%s:%d", c.ChildResourceName("frontend"), c.GetNamespace(), *c.Spec.Services.Frontend.Port)
 }
 

--- a/api/v1beta1/temporalcluster_types.go
+++ b/api/v1beta1/temporalcluster_types.go
@@ -1184,7 +1184,7 @@ func (c *TemporalCluster) ChildResourceName(resource string) string {
 func (c *TemporalCluster) GetPublicClientAddress() string {
 	// Use internal frontend if it's enabled, otherwise use regular frontend
 	if c.Spec.Services != nil && c.Spec.Services.InternalFrontend.IsEnabled() {
-		return fmt.Sprintf("%s.%s:%d", c.ChildResourceName("internalFrontend"), c.GetNamespace(), *c.Spec.Services.InternalFrontend.Port)
+		return fmt.Sprintf("%s.%s:%d", c.ChildResourceName("internal-frontend-headless"), c.GetNamespace(), *c.Spec.Services.InternalFrontend.Port)
 	}
 	return fmt.Sprintf("%s.%s:%d", c.ChildResourceName("frontend"), c.GetNamespace(), *c.Spec.Services.Frontend.Port)
 }


### PR DESCRIPTION
Implements [957](https://github.com/alexandrevilain/temporal-operator/issues/957)

## Summary

- The GetPublicClientAddress method was always returning the frontend service address regardless of whether internal frontend was enabled.
- This caused authentication issues for internal operations like creating the default namespace when auth was configured on the public frontend.

### Validation
```
2025-09-01T06:55:20Z	INFO	Starting reconciliation	{"controller": "temporalnamespace", "controllerGroup": "temporal.io", "controllerKind": "TemporalNamespace", "TemporalNamespace": {"name":"default","namespace":"temporal"}, "namespace": "temporal", "name": "default", "reconcileID": "38d32796-6ead-41a1-adb0-e60f629eb8dd"}
2025-09-01T06:55:20Z	DEBUG	Connecting to temporal cluster	{"controller": "temporalnamespace", "controllerGroup": "temporal.io", "controllerKind": "TemporalNamespace", "TemporalNamespace": {"name":"default","namespace":"temporal"}, "namespace": "temporal", "name": "default", "reconcileID": "38d32796-6ead-41a1-adb0-e60f629eb8dd", "address": "temporal-cluster-internal-frontend-headless.temporal:7236"}
2025-09-01T06:55:20Z	INFO	Successfully reconciled namespace	{"controller": "temporalnamespace", "controllerGroup": "temporal.io", "controllerKind": "TemporalNamespace", "TemporalNamespace": {"name":"default","namespace":"temporal"}, "namespace": "temporal", "name": "default", "reconcileID": "38d32796-6ead-41a1-adb0-e60f629eb8dd", "namespace": "default"}
```