### PR TITLE
Preserve existing pod annotations/labels to fix restarting Temporal deployments

### DIFF
--- a/internal/resource/admintools/deployment_builder.go
+++ b/internal/resource/admintools/deployment_builder.go
@@ -128,7 +128,7 @@ func (b *DeploymentBuilder) Update(object client.Object) error {
 	}
 
 	deployment.Spec.Template = corev1.PodTemplateSpec{
-		ObjectMeta: meta.BuildPodObjectMeta(b.instance, "admintools", b.configHash),
+		ObjectMeta: meta.BuildPodObjectMeta(b.instance, "admintools", b.configHash, deployment.Spec.Template.ObjectMeta),
 		Spec: corev1.PodSpec{
 			ImagePullSecrets: b.instance.Spec.ImagePullSecrets,
 			Containers: []corev1.Container{

--- a/internal/resource/base/deployment_builder.go
+++ b/internal/resource/base/deployment_builder.go
@@ -341,7 +341,7 @@ func (b *DeploymentBuilder) Update(object client.Object) error {
 	}
 
 	deployment.Spec.Template = corev1.PodTemplateSpec{
-		ObjectMeta: meta.BuildPodObjectMeta(b.instance, b.serviceName, b.configHash),
+		ObjectMeta: meta.BuildPodObjectMeta(b.instance, b.serviceName, b.configHash, deployment.Spec.Template.ObjectMeta),
 		Spec: corev1.PodSpec{
 			ServiceAccountName:       b.instance.ChildResourceName(b.serviceName),
 			DeprecatedServiceAccount: b.instance.ChildResourceName(b.serviceName),

--- a/internal/resource/meta/pod.go
+++ b/internal/resource/meta/pod.go
@@ -31,17 +31,21 @@ const (
 )
 
 // BuildPodObjectMeta return ObjectMeta for the service (frontend, ui, admintools) of the provided Cluster.
-func BuildPodObjectMeta(instance *v1beta1.TemporalCluster, service, configHash string) metav1.ObjectMeta {
+// It merges existing pod template labels and annotations with the operator-managed ones,
+// so that externally-added annotations (e.g. from kubectl rollout restart) are preserved.
+func BuildPodObjectMeta(instance *v1beta1.TemporalCluster, service, configHash string, existing metav1.ObjectMeta) metav1.ObjectMeta {
 	instanceAnnotations := metadata.FilterAnnotations(instance.Annotations, func(k, _ string) bool {
 		return k != "kubectl.kubernetes.io/last-applied-configuration"
 	})
 
 	return metav1.ObjectMeta{
 		Labels: metadata.Merge(
+			existing.Labels,
 			istio.GetLabels(instance),
 			metadata.GetLabels(instance, service, instance.Spec.Version, instance.Labels),
 		),
 		Annotations: metadata.Merge(
+			existing.Annotations,
 			linkerd.GetAnnotations(instance),
 			istio.GetAnnotations(instance),
 			prometheus.GetAnnotations(instance),

--- a/internal/resource/meta/pod_test.go
+++ b/internal/resource/meta/pod_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/alexandrevilain/temporal-operator/api/v1beta1"
 	"github.com/alexandrevilain/temporal-operator/internal/resource/meta"
+	"github.com/alexandrevilain/temporal-operator/pkg/version"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -32,7 +33,9 @@ func newTestCluster() *v1beta1.TemporalCluster {
 			Name:      "test-cluster",
 			Namespace: "default",
 		},
-		Spec: v1beta1.TemporalClusterSpec{},
+		Spec: v1beta1.TemporalClusterSpec{
+			Version: version.MustNewVersionFromString("1.24.1"),
+		},
 	}
 }
 

--- a/internal/resource/meta/pod_test.go
+++ b/internal/resource/meta/pod_test.go
@@ -41,7 +41,7 @@ func TestBuildPodObjectMeta_PreservesExistingAnnotations(t *testing.T) {
 	existing := metav1.ObjectMeta{
 		Annotations: map[string]string{
 			"kubectl.kubernetes.io/restartedAt": "2024-01-01T00:00:00Z",
-			"custom-annotation":                "custom-value",
+			"custom-annotation":                 "custom-value",
 		},
 	}
 

--- a/internal/resource/meta/pod_test.go
+++ b/internal/resource/meta/pod_test.go
@@ -1,0 +1,92 @@
+// Licensed to Alexandre VILAIN under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Alexandre VILAIN licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/alexandrevilain/temporal-operator/api/v1beta1"
+	"github.com/alexandrevilain/temporal-operator/internal/resource/meta"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestCluster() *v1beta1.TemporalCluster {
+	return &v1beta1.TemporalCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TemporalClusterSpec{},
+	}
+}
+
+func TestBuildPodObjectMeta_PreservesExistingAnnotations(t *testing.T) {
+	instance := newTestCluster()
+	existing := metav1.ObjectMeta{
+		Annotations: map[string]string{
+			"kubectl.kubernetes.io/restartedAt": "2024-01-01T00:00:00Z",
+			"custom-annotation":                "custom-value",
+		},
+	}
+
+	result := meta.BuildPodObjectMeta(instance, "frontend", "abc123", existing)
+
+	assert.Equal(t, "2024-01-01T00:00:00Z", result.Annotations["kubectl.kubernetes.io/restartedAt"])
+	assert.Equal(t, "custom-value", result.Annotations["custom-annotation"])
+	assert.Equal(t, "abc123", result.Annotations["operator.temporal.io/config"])
+}
+
+func TestBuildPodObjectMeta_PreservesExistingLabels(t *testing.T) {
+	instance := newTestCluster()
+	existing := metav1.ObjectMeta{
+		Labels: map[string]string{
+			"custom-label": "custom-value",
+		},
+	}
+
+	result := meta.BuildPodObjectMeta(instance, "frontend", "abc123", existing)
+
+	assert.Equal(t, "custom-value", result.Labels["custom-label"])
+	assert.Equal(t, "test-cluster", result.Labels["app.kubernetes.io/name"])
+	assert.Equal(t, "frontend", result.Labels["app.kubernetes.io/component"])
+}
+
+func TestBuildPodObjectMeta_OperatorAnnotationsOverrideExisting(t *testing.T) {
+	instance := newTestCluster()
+	existing := metav1.ObjectMeta{
+		Annotations: map[string]string{
+			"operator.temporal.io/config": "old-hash",
+		},
+	}
+
+	result := meta.BuildPodObjectMeta(instance, "frontend", "new-hash", existing)
+
+	assert.Equal(t, "new-hash", result.Annotations["operator.temporal.io/config"])
+}
+
+func TestBuildPodObjectMeta_EmptyExistingObjectMeta(t *testing.T) {
+	instance := newTestCluster()
+	existing := metav1.ObjectMeta{}
+
+	result := meta.BuildPodObjectMeta(instance, "frontend", "abc123", existing)
+
+	assert.Equal(t, "abc123", result.Annotations["operator.temporal.io/config"])
+	assert.Equal(t, "test-cluster", result.Labels["app.kubernetes.io/name"])
+	assert.Equal(t, "frontend", result.Labels["app.kubernetes.io/component"])
+}

--- a/internal/resource/ui/deployment_builder.go
+++ b/internal/resource/ui/deployment_builder.go
@@ -121,7 +121,7 @@ func (b *DeploymentBuilder) Update(object client.Object) error {
 		MatchLabels: metadata.LabelsSelector(b.instance, "ui"),
 	}
 	deployment.Spec.Template = corev1.PodTemplateSpec{
-		ObjectMeta: meta.BuildPodObjectMeta(b.instance, "ui", b.configHash),
+		ObjectMeta: meta.BuildPodObjectMeta(b.instance, "ui", b.configHash, deployment.Spec.Template.ObjectMeta),
 		Spec: corev1.PodSpec{
 			ImagePullSecrets: b.instance.Spec.ImagePullSecrets,
 			Containers: []corev1.Container{


### PR DESCRIPTION
This fixes #858 where a `rollout restart` would cause in the new pod being terminated and the old pod continuing to persist.  Now, we merge in the annotations/labels that are added by Kubernetes for `rollout restart` such that it can complete the rollout.

I think this will end up being related to #746, but I don't have additional details there yet.

As a caveat, this was written with Copilot and Opus 4.6 under my supervision in VSCode, but I tested this in my homelab cluster already.