### PR TITLE
fix dynamicconfig parsing of long integers

### DIFF
--- a/pkg/temporal/config/dynamicconfig.go
+++ b/pkg/temporal/config/dynamicconfig.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/alexandrevilain/temporal-operator/api/v1beta1"
@@ -80,14 +81,53 @@ func constrainedValueToYamlConstrainedValue(cv *v1beta1.ConstrainedValue) (YamlC
 		constraints["shardid"] = cv.Constraints.ShardID
 	}
 
+	// Decode the raw JSON value using a decoder with UseNumber so that JSON
+	// numbers are preserved as json.Number instead of being coerced to float64.
+	// Without this, an integer like 2097152 becomes float64(2097152), which
+	// yaml.v3 later marshals in scientific notation (2.097152e+06). Temporal's
+	// file based dynamic config client then fails to parse it for settings that
+	// expect an integer.
+	decoder := json.NewDecoder(bytes.NewReader(cv.Value.Raw))
+	decoder.UseNumber()
+
 	var value any
-	err := json.Unmarshal(cv.Value.Raw, &value)
+	err := decoder.Decode(&value)
 	if err != nil {
 		return YamlConstrainedValue{}, err
 	}
 
 	return YamlConstrainedValue{
 		Constraints: constraints,
-		Value:       value,
+		Value:       normalizeJSONNumbers(value),
 	}, nil
+}
+
+// normalizeJSONNumbers recursively walks a value decoded from JSON with
+// json.Decoder.UseNumber and converts every json.Number into a concrete int or
+// float64. Integers are converted to int to match the type yaml.v3 produces
+// when it unmarshals the config map back, keeping the reconciliation deep-equal
+// comparison stable.
+func normalizeJSONNumbers(value any) any {
+	switch v := value.(type) {
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return int(i)
+		}
+		if f, err := v.Float64(); err == nil {
+			return f
+		}
+		return v.String()
+	case map[string]any:
+		for key, val := range v {
+			v[key] = normalizeJSONNumbers(val)
+		}
+		return v
+	case []any:
+		for i, val := range v {
+			v[i] = normalizeJSONNumbers(val)
+		}
+		return v
+	default:
+		return value
+	}
 }

--- a/pkg/temporal/config/dynamicconfig_test.go
+++ b/pkg/temporal/config/dynamicconfig_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/alexandrevilain/temporal-operator/pkg/temporal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -46,7 +47,7 @@ func TestDynamicConfigToYamlDynamicConfig(t *testing.T) {
 				"matching.numTaskqueueReadPartitions": {
 					{
 						Constraints: map[string]any{},
-						Value:       float64(5),
+						Value:       int(5),
 					},
 				},
 			},
@@ -70,7 +71,7 @@ func TestDynamicConfigToYamlDynamicConfig(t *testing.T) {
 						Constraints: map[string]any{
 							"namespace": "accounting",
 						},
-						Value: float64(5),
+						Value: int(5),
 					},
 				},
 			},
@@ -98,7 +99,7 @@ func TestDynamicConfigToYamlDynamicConfig(t *testing.T) {
 							"taskqueuename": "accounting-tq",
 							"shardid":       int32(1),
 						},
-						Value: float64(5),
+						Value: int(5),
 					},
 				},
 			},
@@ -122,7 +123,7 @@ func TestDynamicConfigToYamlDynamicConfig(t *testing.T) {
 						Constraints: map[string]any{
 							"tasktype": "Workflow",
 						},
-						Value: float64(5),
+						Value: int(5),
 					},
 				},
 			},
@@ -146,7 +147,7 @@ func TestDynamicConfigToYamlDynamicConfig(t *testing.T) {
 						Constraints: map[string]any{
 							"historytasktype": "ActivityRetryTimer",
 						},
-						Value: float64(5),
+						Value: int(5),
 					},
 				},
 			},
@@ -160,4 +161,57 @@ func TestDynamicConfigToYamlDynamicConfig(t *testing.T) {
 			assert.EqualValues(tt, test.expectedYamlDynamicConfig, result)
 		})
 	}
+}
+
+// TestDynamicConfigToYamlDynamicConfigLargeInteger ensures that large integer
+// values are marshaled as plain integers and not in floating-point scientific
+// notation (e.g. 2.097152e+06). Temporal's file based dynamic config client
+// parses the resulting YAML and fails to load a setting when the number is
+// rendered as a float for a setting that expects an integer.
+func TestDynamicConfigToYamlDynamicConfigLargeInteger(t *testing.T) {
+	dc := &v1beta1.DynamicConfigSpec{
+		Values: map[string][]v1beta1.ConstrainedValue{
+			"limit.blobSize.error": {
+				{
+					Value: &apiextensionsv1.JSON{Raw: []byte(`2097152`)},
+				},
+			},
+		},
+	}
+
+	result, err := config.DynamicConfigToYamlDynamicConfig(dc)
+	require.NoError(t, err)
+
+	out, err := yaml.Marshal(result)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "value: 2097152")
+	assert.NotContains(t, string(out), "2.097152e+06")
+}
+
+// TestDynamicConfigToYamlDynamicConfigNestedLargeInteger ensures large integers
+// nested inside object/array values are also rendered as plain integers, since
+// json.Unmarshal into an any coerces every number (including nested ones) to
+// float64.
+func TestDynamicConfigToYamlDynamicConfigNestedLargeInteger(t *testing.T) {
+	dc := &v1beta1.DynamicConfigSpec{
+		Values: map[string][]v1beta1.ConstrainedValue{
+			"history.defaultActivityRetryPolicy": {
+				{
+					Value: &apiextensionsv1.JSON{Raw: []byte(`{"MaximumInterval": 2097152, "Sizes": [1048576, 4194304]}`)},
+				},
+			},
+		},
+	}
+
+	result, err := config.DynamicConfigToYamlDynamicConfig(dc)
+	require.NoError(t, err)
+
+	out, err := yaml.Marshal(result)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "MaximumInterval: 2097152")
+	assert.Contains(t, string(out), "- 1048576")
+	assert.Contains(t, string(out), "- 4194304")
+	assert.NotContains(t, string(out), "e+06")
 }


### PR DESCRIPTION
### Problem

`DynamicConfigToYamlDynamicConfig` decoded CRD values via `json.Unmarshal` into an `any`, which always coerces JSON numbers to `float64`. A large integer like `2097152` became `float64(2097152)`, and yaml.v3 then marshaled it in scientific notation (`2.097152e+06`). Temporal's file-based dynamic config client fails to parse this for settings that expect an integer.

### Fix



- Added a test reproducing the scientific-notation bug (`2097152` → `value: 2097152`).
- Added a test covering large integers nested inside objects/arrays.
- Updated existing table tests to expect `int` instead of `float64` for integer values.

### Note

This changes integer dynamic config values from `float64` to `int` in `YamlConstrainedValue.Value`. Existing config maps holding values in scientific notation get rewritten once to the clean integer form on upgrade.

Fixes https://github.com/alexandrevilain/temporal-operator/issues/517

